### PR TITLE
Correct naming convention of enum

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/Energy.java
+++ b/src/main/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/Energy.java
@@ -6,11 +6,11 @@ package cz.upce.fei.nnptp.em.nnptp.energymonitor;
 public class Energy {
 
     public static enum EnergyType {
-        Electricity,
-        Gas,
-        ColdWater,
-        HotWater,
-        CentralHeating
+        ELECTRICITY,
+        GAS,
+        COLD_WATER,
+        HOT_WATER,
+        CENTRAL_HEATING
     }
 
     private String name;


### PR DESCRIPTION
Correcting naming convention in enum EnergyType. 
Replacing current camel case with screaming snake case.