### PR TITLE
Correct naming convention of enum EnergyType

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/Energy.java
+++ b/src/main/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/Energy.java
@@ -6,11 +6,11 @@ package cz.upce.fei.nnptp.em.nnptp.energymonitor;
 public class Energy {
 
     public static enum EnergyType {
-        Electricity,
-        Gas,
-        ColdWater,
-        HotWater,
-        CentralHeating
+        ELECTRICITY,
+        GAS,
+        COLD_WATER,
+        HOT_WATER,
+        CENTRAL_HEATING
     }
 
     private String name;

--- a/src/test/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/MeterTest.java
+++ b/src/test/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/MeterTest.java
@@ -196,7 +196,7 @@ public class MeterTest {
     
     @Test
     public void testCalculatePriceWithCumulativeMeter() {
-        Energy energy = new Energy(Energy.EnergyType.Electricity);
+        Energy energy = new Energy(Energy.EnergyType.ELECTRICITY);
         energy.setPricePerMeasuredUnit(10.0);
 
         List<ObservedValue> observedValues = new ArrayList<>();
@@ -212,7 +212,7 @@ public class MeterTest {
 
     @Test
     public void testCalculatePriceWithActualMeter() {
-        Energy energy = new Energy(Energy.EnergyType.Gas);
+        Energy energy = new Energy(Energy.EnergyType.GAS);
         energy.setPricePerMeasuredUnit(20.0);
 
         List<ObservedValue> observedValues = new ArrayList<>();
@@ -228,7 +228,7 @@ public class MeterTest {
 
     @Test
     public void testCalculatePriceWithPriceChange() {
-        Energy energy = new Energy(Energy.EnergyType.HotWater);
+        Energy energy = new Energy(Energy.EnergyType.HOT_WATER);
         energy.setPricePerMeasuredUnit(5.0);
         
         List<ObservedValue> observedValues = new ArrayList<>();
@@ -251,7 +251,7 @@ public class MeterTest {
     
     @Test
     public void testCalculatePriceWithPriceAndMeterChange() {
-        Energy energy = new Energy(Energy.EnergyType.HotWater);
+        Energy energy = new Energy(Energy.EnergyType.HOT_WATER);
         energy.setPricePerMeasuredUnit(5.0);
         
         List<ObservedValue> observedValues = new ArrayList<>();


### PR DESCRIPTION
Correcting naming convention in enum EnergyType.
Replacing current camel case with screaming snake case. 
Modification test that use the modified enum EnergyType.