### PR TITLE
Add calculate price with date from and date to.

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/Meter.java
+++ b/src/main/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/Meter.java
@@ -1,7 +1,7 @@
 package cz.upce.fei.nnptp.em.nnptp.energymonitor;
 
-import cz.upce.fei.nnptp.em.nnptp.energymonitor.entity.ObservedTagsAndFlags;
 import cz.upce.fei.nnptp.em.nnptp.energymonitor.entity.ObservedValue;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -127,6 +127,10 @@ public class Meter {
     }
 
     public double calculatePrice() {
+        return calculatePrice(null, null);
+    }
+
+    public double calculatePrice(LocalDateTime from, LocalDateTime to) {
         double totalPrice = 0.0;
         double currentUnitPrice = energy.getPricePerMeasuredUnit();
         double lastValue = 0.0;
@@ -135,8 +139,10 @@ public class Meter {
             return 0.0;
         }
 
-        for (int i = 0; i < getObservedValues().size(); i++) {
-            ObservedValue observedValue = getObservedValues().get(i);
+        List<ObservedValue> observedValuesInTimeInterval = getObservedValuesInTimeInterval(from, to);
+
+        for (int i = 0; i < observedValuesInTimeInterval.size(); i++) {
+            ObservedValue observedValue = observedValuesInTimeInterval.get(i);
 
             double consumedElectricity = 0.0;
             if (meterType == MeterType.CUMULATIVE_VALUE) {
@@ -162,10 +168,29 @@ public class Meter {
         return totalPrice;
     }
 
-    public double calculatePrice(LocalDateTime from, LocalDateTime to) {
-        // TODO
-        throw new RuntimeException();
+    private List<ObservedValue> getObservedValuesInTimeInterval(LocalDateTime from, LocalDateTime to) {
+        List<ObservedValue> observedValuesInTimeInterval;
+        if (from == null && to == null) {
+            observedValuesInTimeInterval = observedValues;
+        } else {
+            observedValuesInTimeInterval = observedValues.stream()
+                    .filter((observedValue) -> isValueInTimeInterval(from, to, observedValue))
+                    .toList();
+        }
+        return observedValuesInTimeInterval;
+    }
 
+    private boolean isValueInTimeInterval(LocalDateTime from, LocalDateTime to, ObservedValue observedValue) {
+        if (from == null && to == null) {
+            return true;
+        } else if (to == null) {
+            return observedValue.getLocalDateTime().isAfter(from) || observedValue.getLocalDateTime().isEqual(from);
+        } else if (from == null) {
+            return observedValue.getLocalDateTime().isBefore(to) || observedValue.getLocalDateTime().isEqual(to);
+        } else {
+            return (observedValue.getLocalDateTime().isAfter(from) || observedValue.getLocalDateTime().isEqual(from)) &&
+                    (observedValue.getLocalDateTime().isBefore(to) || observedValue.getLocalDateTime().isEqual(to));
+        }
     }
 
 }

--- a/src/test/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/MeterTest.java
+++ b/src/test/java/cz/upce/fei/nnptp/em/nnptp/energymonitor/MeterTest.java
@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  */
 public class MeterTest {
-    
+
     public MeterTest() {
     }
-    
+
     @Test
     public void testCalculateConsumedElectricityInIntervalActual() {
         List<ObservedValue> list = new ArrayList<>();
@@ -29,9 +29,9 @@ public class MeterTest {
         Meter meter = new Meter(null, new Distribution("Cez", "Praha"), Meter.MeterType.ACTUAL_VALUE, list);
         
         double totalConsumedPower = meter.calculateConsumedElectricity(time.minusDays(3), time.plusDays(5));
-        assertEquals(29.1, totalConsumedPower);       
+        assertEquals(29.1, totalConsumedPower);
     }
-    
+
     @Test
     public void testCalculateConsumedElectricityInIntervalCumulative() {
         List<ObservedValue> list = new ArrayList<>();
@@ -46,9 +46,9 @@ public class MeterTest {
         Meter meter = new Meter(null, new Distribution("Cez", "Praha"), Meter.MeterType.CUMULATIVE_VALUE, list);
         
         double totalConsumedPower = meter.calculateConsumedElectricity(time.minusDays(3), time.plusDays(5));
-        assertEquals(16.0, totalConsumedPower);       
+        assertEquals(16.0, totalConsumedPower);
     }
-    
+
     @Test
     public void testCalculateConsumedElectricityInIntervalEmpty() {
         List<ObservedValue> list = new ArrayList<>();
@@ -58,7 +58,7 @@ public class MeterTest {
         double totalConsumedPower = meter.calculateConsumedElectricity(time.minusDays(3), time.plusDays(5));
         assertEquals(0.0, totalConsumedPower);
     }
-    
+
     @Test
     public void testCalculateConsumedElectricityInIntervalNull() {
         LocalDateTime time = LocalDateTime.now();
@@ -66,24 +66,24 @@ public class MeterTest {
         double totalConsumedPower = meter.calculateConsumedElectricity(time.minusDays(3), time.plusDays(5));
         assertEquals(0.0, totalConsumedPower);
     }
-    
-        @Test
+
+    @Test
     public void testCalculateConsumedElectricityInIntervalCumulativeChangedMeter() {
         List<ObservedValue> list = new ArrayList<>();
         LocalDateTime time = LocalDateTime.now();
-        list.add(new ObservedValue(time.minusDays(4),1.3));
-        list.add(new ObservedValue(time.minusDays(2),2.6));
-        list.add(new ObservedValue(time,5.5));
-        
-        ObservedValue observedWithFirstNewMeter = new ObservedValue(time.plusDays(1),12.0);
+        list.add(new ObservedValue(time.minusDays(4), 1.3));
+        list.add(new ObservedValue(time.minusDays(2), 2.6));
+        list.add(new ObservedValue(time, 5.5));
+
+        ObservedValue observedWithFirstNewMeter = new ObservedValue(time.plusDays(1), 12.0);
         observedWithFirstNewMeter.getTagsAndFlags().add(new ObservedTagsAndFlags.MeterReplacedJustAfterMeasurementTag(
                 "T1", 40.0));
         list.add(observedWithFirstNewMeter);
-                
-        list.add(new ObservedValue(time.plusDays(1),52.0));
-        list.add(new ObservedValue(time.plusDays(4),58.6));
-        
-        ObservedValue observedWithSecondNewMeter = new ObservedValue(time.plusDays(9),62.6);
+
+        list.add(new ObservedValue(time.plusDays(1), 52.0));
+        list.add(new ObservedValue(time.plusDays(4), 58.6));
+
+        ObservedValue observedWithSecondNewMeter = new ObservedValue(time.plusDays(9), 62.6);
         observedWithSecondNewMeter.getTagsAndFlags().add(new ObservedTagsAndFlags.MeterReplacedJustAfterMeasurementTag(
                 "T2", 20.0));
         list.add(observedWithSecondNewMeter);
@@ -92,7 +92,7 @@ public class MeterTest {
         Meter meter = new Meter(null, new Distribution("Cez", "Praha"), Meter.MeterType.CUMULATIVE_VALUE, list);
         
         double totalConsumedPower = meter.calculateConsumedElectricity(time.minusDays(3), time.plusDays(10));
-        assertEquals(40.6, totalConsumedPower);       
+        assertEquals(40.6, totalConsumedPower);
     }
 
     @Test
@@ -193,7 +193,7 @@ public class MeterTest {
         double consumedPower = meter.calculateConsumedElectricity();
         assertEquals(60.0, consumedPower);
     }
-    
+
     @Test
     public void testCalculatePriceWithCumulativeMeter() {
         Energy energy = new Energy(Energy.EnergyType.ELECTRICITY);
@@ -230,9 +230,9 @@ public class MeterTest {
     public void testCalculatePriceWithPriceChange() {
         Energy energy = new Energy(Energy.EnergyType.HOT_WATER);
         energy.setPricePerMeasuredUnit(5.0);
-        
+
         List<ObservedValue> observedValues = new ArrayList<>();
-        ObservedValue value1 = new ObservedValue(LocalDateTime.now(), 200);      
+        ObservedValue value1 = new ObservedValue(LocalDateTime.now(), 200);
         ObservedValue value2 = new ObservedValue(LocalDateTime.now().plusHours(5), 300);
         ObservedValue value3 = new ObservedValue(LocalDateTime.now().plusHours(8), 350);
 
@@ -248,14 +248,14 @@ public class MeterTest {
         double expectedPrice = 1000.0;
         assertEquals(expectedPrice, meter.calculatePrice());
     }
-    
+
     @Test
     public void testCalculatePriceWithPriceAndMeterChange() {
         Energy energy = new Energy(Energy.EnergyType.HOT_WATER);
         energy.setPricePerMeasuredUnit(5.0);
-        
+
         List<ObservedValue> observedValues = new ArrayList<>();
-        ObservedValue value1 = new ObservedValue(LocalDateTime.now(), 200);      
+        ObservedValue value1 = new ObservedValue(LocalDateTime.now(), 200);
         ObservedValue value2 = new ObservedValue(LocalDateTime.now().plusHours(5), 300);
         ObservedValue value3 = new ObservedValue(LocalDateTime.now().plusHours(8), 150);
 
@@ -273,13 +273,74 @@ public class MeterTest {
         double expectedPrice = 1500.0;
         assertEquals(expectedPrice, meter.calculatePrice());
     }
-    
-        public void testAddToTAgsAndFlags() {
-            ObservedValue observedValue = new ObservedValue(LocalDateTime.now(), 50.0);
-            observedValue.addTagsAndFlags(new ObservedTagsAndFlags.MeterReplacedJustAfterMeasurementTag(
+
+    @Test
+    public void testCalculatePriceWithCumulativeMeterInInterval() {
+        Energy energy = new Energy(Energy.EnergyType.ELECTRICITY);
+        energy.setPricePerMeasuredUnit(10.0);
+
+        LocalDateTime valuesFrom = LocalDateTime.now();
+        LocalDateTime from = valuesFrom.plusHours(1);
+        LocalDateTime to = valuesFrom.plusHours(2);
+
+        List<ObservedValue> observedValues = new ArrayList<>();
+        observedValues.add(new ObservedValue(valuesFrom, 100.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(1), 120.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(2), 180.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(3), 280.0));
+
+        Meter meter = new Meter(energy, null, Meter.MeterType.CUMULATIVE_VALUE, observedValues);
+
+        double expectedPrice = 600.0;
+        assertEquals(expectedPrice, meter.calculatePrice(from, to));
+    }
+
+    @Test
+    public void testCalculatePriceWithCumulativeMeterFromDate() {
+        Energy energy = new Energy(Energy.EnergyType.ELECTRICITY);
+        energy.setPricePerMeasuredUnit(10.0);
+
+        LocalDateTime valuesFrom = LocalDateTime.now();
+        LocalDateTime from = valuesFrom.plusHours(1);
+
+        List<ObservedValue> observedValues = new ArrayList<>();
+        observedValues.add(new ObservedValue(valuesFrom, 100.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(1), 120.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(2), 180.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(3), 280.0));
+
+        Meter meter = new Meter(energy, null, Meter.MeterType.CUMULATIVE_VALUE, observedValues);
+
+        double expectedPrice = 1600.0;
+        assertEquals(expectedPrice, meter.calculatePrice(from, null));
+    }
+
+    @Test
+    public void testCalculatePriceWithCumulativeMeterToDate() {
+        Energy energy = new Energy(Energy.EnergyType.ELECTRICITY);
+        energy.setPricePerMeasuredUnit(10.0);
+
+        LocalDateTime valuesFrom = LocalDateTime.now();
+        LocalDateTime to = valuesFrom.plusHours(1);
+
+        List<ObservedValue> observedValues = new ArrayList<>();
+        observedValues.add(new ObservedValue(valuesFrom, 100.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(1), 120.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(2), 180.0));
+        observedValues.add(new ObservedValue(valuesFrom.plusHours(3), 280.0));
+
+        Meter meter = new Meter(energy, null, Meter.MeterType.CUMULATIVE_VALUE, observedValues);
+
+        double expectedPrice = 200.0;
+        assertEquals(expectedPrice, meter.calculatePrice(null, to));
+    }
+
+    public void testAddToTAgsAndFlags() {
+        ObservedValue observedValue = new ObservedValue(LocalDateTime.now(), 50.0);
+        observedValue.addTagsAndFlags(new ObservedTagsAndFlags.MeterReplacedJustAfterMeasurementTag(
                 "newMeterId2", 10.0));
-            observedValue.addTagsAndFlags(new ObservedTagsAndFlags.UnitPriceChangedJustAfterMeasurementTag(10.0));
-        
+        observedValue.addTagsAndFlags(new ObservedTagsAndFlags.UnitPriceChangedJustAfterMeasurementTag(10.0));
+
         double listSize = observedValue.getTagsAndFlags().size();
         assertEquals(2, listSize);
     }


### PR DESCRIPTION
Implemented method which makes possible to calculate price only for observedValues in given time range. It is possible to select values restricted from date, to date or both.